### PR TITLE
Align CDK stack with API Gateway IaC migration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,7 @@ env:
   ENV_NAME: dev
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
   RUN_BOOTSTRAP: ${{ vars.RUN_BOOTSTRAP || 'false' }}
-  # API Gateway SourceArn propagated from GitHub Environment variable
-  API_GATEWAY_SOURCE_ARN: ${{ vars.API_GATEWAY_SOURCE_ARN }}
+
 
 jobs:
   build-validate-test:
@@ -149,6 +148,5 @@ jobs:
         env:
           ENV_NAME: ${{ env.ENV_NAME }}
           LAMBDA_ZIP_PATH: "./assets/lambda.zip"
-          API_GATEWAY_SOURCE_ARN: ${{ env.API_GATEWAY_SOURCE_ARN }}
         run: |
-          npx cdk deploy --require-approval never -c environment=${ENV_NAME} -c apiGatewaySourceArn=${API_GATEWAY_SOURCE_ARN}
+          npx cdk deploy --require-approval never -c environment=${ENV_NAME}

--- a/docs/issues/002-api-gateway-integration-alignment.md
+++ b/docs/issues/002-api-gateway-integration-alignment.md
@@ -1,0 +1,166 @@
+# Task 2: Align tg-assistant with tg-assistant-infra API Gateway Changes
+
+## Summary
+
+`tg-assistant-infra` now manages the API Gateway as IaC (previously configured manually). Review tg-assistant's CDK stack and CD pipeline to ensure they are properly integrated with the new infra-managed API Gateway, and identify any missing or redundant integration points.
+
+## Context
+
+### Before (manual API Gateway)
+- API Gateway was created manually in AWS console
+- `tg-assistant` CDK stack accepted `apiGatewaySourceArn` as a CDK context parameter
+- The source ARN was stored as a GitHub Actions repository variable (`API_GATEWAY_SOURCE_ARN`)
+- The CD pipeline passed it: `npx cdk deploy ... -c apiGatewaySourceArn=${API_GATEWAY_SOURCE_ARN}`
+
+### After (IaC API Gateway in tg-assistant-infra)
+- `tg-assistant-infra` now provisions the API Gateway via `ApiGatewayStack`
+- The API Gateway stack exports its source ARN to SSM: `/automation/{env}/api-gateway/source-arn`
+- Other exports: REST API ID, URL, domain name, stage name
+- The API Gateway stack references the Lambda by function name: `telegram-webhook-lambda-{env}`
+- The API Gateway creates a `LambdaIntegration` with the Lambda (AWS_PROXY, 29s timeout)
+
+## Analysis: What Needs to Change
+
+### 1. Lambda Invoke Permission (Resource-Based Policy)
+
+**Current state** in `tg-assistant` (`infrastructure/lib/tg-assistant-lambda-stack.ts:81-99`):
+```typescript
+const sourceArnRaw =
+  apiGatewaySourceArn ?? (this.node.tryGetContext('apiGatewaySourceArn') as unknown);
+// ... creates CfnPermission if sourceArn is provided
+```
+
+**Issue**: The source ARN is passed as a hardcoded CDK context or GitHub variable. Now that tg-assistant-infra exports it to SSM (`/automation/{env}/api-gateway/source-arn`), tg-assistant should read it from SSM at synth time instead of requiring it as a context parameter.
+
+**Recommended change**:
+```typescript
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+
+// Read API Gateway source ARN from SSM (exported by tg-assistant-infra)
+const sourceArn = StringParameter.valueForStringParameter(
+  this,
+  `/automation/${environmentName}/api-gateway/source-arn`,
+);
+
+new lambda.CfnPermission(this, 'ApiGatewayInvokePermission', {
+  action: 'lambda:InvokeFunction',
+  functionName: fn.functionArn,
+  principal: 'apigateway.amazonaws.com',
+  sourceArn,
+});
+```
+
+**Trade-off**: This creates a hard dependency on tg-assistant-infra being deployed first. The current context-based approach is more flexible for bootstrapping. Consider supporting both: SSM lookup with context override fallback.
+
+### 2. CD Pipeline: Remove Hardcoded API_GATEWAY_SOURCE_ARN
+
+**Current state** in `.github/workflows/cd.yml`:
+```yaml
+env:
+  API_GATEWAY_SOURCE_ARN: ${{ vars.API_GATEWAY_SOURCE_ARN }}
+
+- name: CDK Deploy
+  run: |
+    npx cdk deploy --require-approval never \
+      -c environment=${ENV_NAME} \
+      -c apiGatewaySourceArn=${API_GATEWAY_SOURCE_ARN}
+```
+
+**Issue**: Once the CDK stack reads the source ARN from SSM, the GitHub variable and context parameter become unnecessary.
+
+**Recommended change**:
+- If SSM approach is adopted: remove the `API_GATEWAY_SOURCE_ARN` variable and context parameter from the deploy command
+- If hybrid approach: keep as fallback but document that SSM is the primary source
+
+### 3. CDK Stack Props: Deprecate apiGatewaySourceArn
+
+**Current state** in `TgAssistantLambdaStackProps`:
+```typescript
+apiGatewaySourceArn?: string | undefined;
+```
+
+**Recommended change**:
+- Option A (clean break): Remove the prop, always read from SSM
+- Option B (gradual migration): Keep prop as override, default to SSM lookup
+- Option C (no change, just document): Keep current behavior, document that the value in GitHub vars must match what tg-assistant-infra deploys
+
+### 4. Deployment Order Dependency
+
+**New concern**: With tg-assistant-infra owning the API Gateway, there's now an implicit deployment order:
+1. `tg-assistant` must be deployed first (Lambda must exist for API Gateway to reference it)
+2. `tg-assistant-infra` deploys next (API Gateway + SQS stacks, exports SSM params)
+3. `tg-assistant` may need to redeploy if it reads source ARN from SSM (to pick up the new value)
+
+**This is the chicken-and-egg problem**: API Gateway references Lambda by name, and Lambda needs the API Gateway source ARN for permissions.
+
+**Possible solutions**:
+- Accept two-phase deployment: first deploy creates Lambda without API Gateway permission, second deploy adds the permission after infra exports the SSM param
+- Use a wildcard source ARN: `arn:aws:execute-api:{region}:{account}:*` (less secure but eliminates the dependency)
+- Keep the current context-based approach for initial setup, switch to SSM for steady-state updates
+
+### 5. Missing: ENVIRONMENT Variable for Lambda
+
+**Current state**: The Lambda has `NODE_ENV=production` and `TELEGRAM_SECRET_ARN` as environment variables, but no `ENVIRONMENT` variable (e.g., `dev`, `test`, `prod`).
+
+**Future need**: When the Lambda starts publishing to SQS (Task 3), it will need to know the environment name to look up SSM parameters like `/automation/{env}/queues/order/url`.
+
+**Recommended change**: Add `ENVIRONMENT` to Lambda environment variables:
+```typescript
+environment: {
+  NODE_ENV: 'production',
+  TELEGRAM_SECRET_ARN: telegramWebhookSecret.secretArn,
+  ENVIRONMENT: environmentName,  // NEW: needed for SSM parameter lookups
+},
+```
+
+### 6. Redundancy Check: No Conflicts Found
+
+The API Gateway in tg-assistant-infra references the Lambda by function name (`telegram-webhook-lambda-{env}`), which matches what tg-assistant's CDK stack creates. There is no conflict or duplication in resource creation - the API Gateway just creates an integration to an existing Lambda.
+
+## Acceptance Criteria
+
+- [ ] Decide on approach for source ARN resolution (SSM vs context vs hybrid)
+- [ ] Update CDK stack to read API Gateway source ARN from SSM (if SSM approach chosen)
+- [ ] Update or remove `API_GATEWAY_SOURCE_ARN` from CD pipeline and GitHub variables
+- [ ] Add `ENVIRONMENT` env var to Lambda (needed for future SQS integration)
+- [ ] Document the deployment order between tg-assistant and tg-assistant-infra
+- [ ] Update CDK tests to reflect any changes
+- [ ] Verify CI workflow's `cdk diff` still works with the new approach
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `infrastructure/lib/tg-assistant-lambda-stack.ts` | SSM lookup for source ARN, add ENVIRONMENT env var |
+| `infrastructure/bin/tg-assistant-lambda.ts` | Update props if interface changes |
+| `.github/workflows/cd.yml` | Remove API_GATEWAY_SOURCE_ARN context parameter (if SSM approach) |
+| `.github/workflows/ci.yml` | Verify cdk diff works without the context param |
+| `infrastructure/test/tg-assistant-lambda-stack.test.ts` | Update tests for new behavior |
+
+## Deployment Order
+
+Cross-repo deployment follows a two-phase pattern:
+
+### Initial Setup (first time)
+1. **Deploy `tg-assistant`** — creates the Lambda function. On first deploy without
+   `tg-assistant-infra`, pass the source ARN explicitly:
+   `npx cdk deploy -c environment=dev -c apiGatewaySourceArn=arn:aws:execute-api:...`
+2. **Deploy `tg-assistant-infra`** — creates the API Gateway with Lambda integration,
+   exports source ARN to SSM at `/automation/{env}/api-gateway/source-arn`
+3. **Redeploy `tg-assistant`** (without `-c apiGatewaySourceArn`) — picks up the SSM
+   value automatically via CloudFormation dynamic reference
+
+### Steady-State Updates
+- Either repo can be deployed independently
+- `tg-assistant` reads the source ARN from SSM automatically — no manual coordination needed
+- To override SSM (e.g., during testing), pass `-c apiGatewaySourceArn=...` as before
+
+### If SSM Parameter Does Not Exist
+CloudFormation will fail the deploy with a clear error. This is expected during
+bootstrapping — use the context override for the initial deploy.
+
+## Risk Assessment
+
+- **Low risk**: Adding `ENVIRONMENT` env var to Lambda (purely additive)
+- **Medium risk**: Changing source ARN resolution from context to SSM (requires tg-assistant-infra deployed first)
+- **Mitigation**: Context parameter retained as fallback override for bootstrapping and testing

--- a/infrastructure/lib/tg-assistant-lambda-stack.ts
+++ b/infrastructure/lib/tg-assistant-lambda-stack.ts
@@ -7,6 +7,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface TgAssistantLambdaStackProps extends StackProps {
   environmentName: string;
@@ -66,6 +67,7 @@ export class TgAssistantLambdaStack extends Stack {
       environment: {
         NODE_ENV: 'production',
         TELEGRAM_SECRET_ARN: telegramWebhookSecret.secretArn,
+        ENVIRONMENT: environmentName,
       },
       logGroup: new logs.LogGroup(this, 'FunctionLogGroup', {
         logGroupName: `/aws/lambda/${lambdaName}`,
@@ -77,33 +79,40 @@ export class TgAssistantLambdaStack extends Stack {
     // Grant Lambda permission to read the secret value
     telegramWebhookSecret.grantRead(fn);
 
-    // Context parameter for external API Gateway invoke permission (full SourceArn provided)
+    // Resolve API Gateway source ARN: explicit context override takes priority,
+    // otherwise read from SSM (exported by tg-assistant-infra ApiGatewayStack).
     const sourceArnRaw =
       apiGatewaySourceArn ?? (this.node.tryGetContext('apiGatewaySourceArn') as unknown);
-    const sourceArn =
+    const contextSourceArn =
       typeof sourceArnRaw === 'string' && sourceArnRaw.trim().length > 0
         ? sourceArnRaw.trim()
         : undefined;
 
-    if (sourceArn) {
-      new lambda.CfnPermission(this, 'ApiGatewayInvokePermission', {
-        action: 'lambda:InvokeFunction',
-        functionName: fn.functionArn,
-        principal: 'apigateway.amazonaws.com',
-        sourceArn,
-      });
-    } else {
-      Annotations.of(this).addWarning(
-        'API Gateway SourceArn not provided. Skipping Lambda invoke permission. Provide context: -c apiGatewaySourceArn=arn:aws:execute-api:...'
+    const sourceArn =
+      contextSourceArn ??
+      StringParameter.valueForStringParameter(
+        this,
+        `/automation/${environmentName}/api-gateway/source-arn`
+      );
+
+    if (contextSourceArn) {
+      Annotations.of(this).addInfo(
+        'Using API Gateway SourceArn from CDK context (explicit override). ' +
+          'Remove -c apiGatewaySourceArn to use SSM parameter instead.'
       );
     }
+
+    new lambda.CfnPermission(this, 'ApiGatewayInvokePermission', {
+      action: 'lambda:InvokeFunction',
+      functionName: fn.functionArn,
+      principal: 'apigateway.amazonaws.com',
+      sourceArn,
+    });
 
     new CfnOutput(this, 'FunctionName', { value: fn.functionName });
     new CfnOutput(this, 'FunctionArn', { value: fn.functionArn });
     new CfnOutput(this, 'LambdaRegion', { value: Stack.of(this).region });
-    if (sourceArn) {
-      new CfnOutput(this, 'ApiGatewaySourceArn', { value: sourceArn });
-    }
+    new CfnOutput(this, 'ApiGatewaySourceArn', { value: sourceArn });
     new CfnOutput(this, 'TelegramWebhookSecretArn', { value: telegramWebhookSecret.secretArn });
   }
 }

--- a/infrastructure/test/__snapshots__/tg-assistant-lambda-stack.test.ts.snap
+++ b/infrastructure/test/__snapshots__/tg-assistant-lambda-stack.test.ts.snap
@@ -1,11 +1,13 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke permission for HTTP API (pattern covered by snapshot) 1`] = `
+exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) SSM fallback uses correct parameter path for environment 1`] = `
 {
   "Description": "Test stack",
   "Outputs": {
     "ApiGatewaySourceArn": {
-      "Value": "arn:aws:execute-api:us-east-1:123456789012:abc123/beta/*",
+      "Value": {
+        "Ref": "SsmParameterValueautomationprodapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter",
+      },
     },
     "FunctionArn": {
       "Value": {
@@ -35,6 +37,10 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueautomationprodapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/automation/prod/api-gateway/source-arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": {
     "ApiGatewayInvokePermission": {
@@ -47,7 +53,9 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke
           ],
         },
         "Principal": "apigateway.amazonaws.com",
-        "SourceArn": "arn:aws:execute-api:us-east-1:123456789012:abc123/beta/*",
+        "SourceArn": {
+          "Ref": "SsmParameterValueautomationprodapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
       },
       "Type": "AWS::Lambda::Permission",
     },
@@ -66,6 +74,7 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke
         },
         "Environment": {
           "Variables": {
+            "ENVIRONMENT": "prod",
             "NODE_ENV": "production",
             "TELEGRAM_SECRET_ARN": {
               "Ref": "TelegramWebhookSecret2F3DC73E",
@@ -129,7 +138,7 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke
             ],
           },
         ],
-        "RoleName": "telegram-webhook-lambda-role-dev",
+        "RoleName": "telegram-webhook-lambda-role-prod",
       },
       "Type": "AWS::IAM::Role",
     },
@@ -169,7 +178,7 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) creates Lambda invoke
           "PasswordLength": 16,
           "SecretStringTemplate": "{}",
         },
-        "Name": "/tg-assistant/telegram-secrets/dev",
+        "Name": "/tg-assistant/telegram-secrets/prod",
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
@@ -209,6 +218,11 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) synthesizes expected 
 {
   "Description": "Test stack",
   "Outputs": {
+    "ApiGatewaySourceArn": {
+      "Value": {
+        "Ref": "SsmParameterValueautomationdevapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter",
+      },
+    },
     "FunctionArn": {
       "Value": {
         "Fn::GetAtt": [
@@ -237,8 +251,28 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) synthesizes expected 
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueautomationdevapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/automation/dev/api-gateway/source-arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": {
+    "ApiGatewayInvokePermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "Function76856677",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Ref": "SsmParameterValueautomationdevapigatewaysourcearnC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "Function76856677": {
       "DependsOn": [
         "LambdaExecutionRoleDefaultPolicy6D69732F",
@@ -254,6 +288,7 @@ exports[`TgAssistantLambdaStack (ZIP-based Node.js Lambda) synthesizes expected 
         },
         "Environment": {
           "Variables": {
+            "ENVIRONMENT": "dev",
             "NODE_ENV": "production",
             "TELEGRAM_SECRET_ARN": {
               "Ref": "TelegramWebhookSecret2F3DC73E",

--- a/infrastructure/test/tg-assistant-lambda-stack.test.ts
+++ b/infrastructure/test/tg-assistant-lambda-stack.test.ts
@@ -100,6 +100,7 @@ describe('TgAssistantLambdaStack (ZIP-based Node.js Lambda)', () => {
           Variables: Match.objectLike({
             NODE_ENV: 'production',
             TELEGRAM_SECRET_ARN: Match.anyValue(),
+            ENVIRONMENT: 'dev',
           }),
         }),
         Handler: 'index.handler',
@@ -142,31 +143,14 @@ describe('TgAssistantLambdaStack (ZIP-based Node.js Lambda)', () => {
     });
   });
 
-  test('does not create Lambda invoke permission when apiId is not provided (default)', () => {
+  test('creates Lambda invoke permission with SSM lookup when no context override', () => {
     // Arrange
     const stack = makeStack({ envName: 'dev' });
 
     // Act
     const template = Template.fromStack(stack);
 
-    // Assert
-    template.resourceCountIs('AWS::Lambda::Permission', 0);
-  });
-
-  test('creates Lambda invoke permission for REST API and outputs SourceArn', () => {
-    // Arrange
-    const stack = makeStack({
-      envName: 'dev',
-      context: {
-        apiGatewaySourceArn:
-          'arn:aws:execute-api:us-east-1:123456789012:abc123/prod/POST/qlibin-assistant-listener',
-      },
-    });
-
-    // Act
-    const template = Template.fromStack(stack);
-
-    // Assert permission exists and outputs include SourceArn and identifiers
+    // Assert: permission always exists (SSM dynamic reference as fallback)
     template.resourceCountIs('AWS::Lambda::Permission', 1);
     template.hasResourceProperties('AWS::Lambda::Permission', {
       Action: 'lambda:InvokeFunction',
@@ -179,19 +163,39 @@ describe('TgAssistantLambdaStack (ZIP-based Node.js Lambda)', () => {
     template.hasOutput('LambdaRegion', Match.anyValue());
   });
 
-  test('creates Lambda invoke permission for HTTP API (pattern covered by snapshot)', () => {
+  test('creates Lambda invoke permission with context override when provided', () => {
     // Arrange
     const stack = makeStack({
       envName: 'dev',
       context: {
-        apiGatewaySourceArn: 'arn:aws:execute-api:us-east-1:123456789012:abc123/beta/*',
+        apiGatewaySourceArn:
+          'arn:aws:execute-api:us-east-1:123456789012:abc123/prod/POST/qlibin-assistant-listener',
       },
     });
 
     // Act
+    const template = Template.fromStack(stack);
+
+    // Assert: permission uses explicit source ARN from context
+    template.resourceCountIs('AWS::Lambda::Permission', 1);
+    template.hasResourceProperties('AWS::Lambda::Permission', {
+      Action: 'lambda:InvokeFunction',
+      Principal: 'apigateway.amazonaws.com',
+      SourceArn:
+        'arn:aws:execute-api:us-east-1:123456789012:abc123/prod/POST/qlibin-assistant-listener',
+    });
+
+    template.hasOutput('ApiGatewaySourceArn', Match.anyValue());
+  });
+
+  test('SSM fallback uses correct parameter path for environment', () => {
+    // Arrange
+    const stack = makeStack({ envName: 'prod' });
+
+    // Act
     const templateJson = Template.fromStack(stack).toJSON();
 
-    // Assert: snapshot captures SourceArn structure including tokens
+    // Assert: snapshot captures SSM dynamic reference structure
     expect(templateJson).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Closes #72

- **SSM lookup for API Gateway source ARN**: CDK stack now reads the source ARN from SSM (`/automation/{env}/api-gateway/source-arn`) exported by `tg-assistant-infra`, with context param retained as override for bootstrapping
- **Added `ENVIRONMENT` env var**: Lambda now has `ENVIRONMENT` set to the environment name, needed for future SSM-based integrations (SQS queues)
- **CD pipeline cleanup**: Removed hardcoded `API_GATEWAY_SOURCE_ARN` GitHub variable and context param from deploy command
- **Deployment order documented**: Added cross-repo deployment sequence to the spec doc

## Test plan

- [x] All 8 CDK tests pass (100% coverage)
- [x] Snapshots updated to reflect SSM dynamic references and ENVIRONMENT env var
- [x] Full `npm run validate` passes in both root and infrastructure
- [ ] CI pipeline runs `cdk diff` successfully with SSM dynamic reference tokens
- [ ] After merge, verify CD deploy picks up SSM value correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)