### PR TITLE
Scaffold npm workspaces structure (#83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ yarn-error.log*
 # Production builds
 dist/
 build/
+packages/*/dist/
+packages/*/coverage/
 *.tsbuildinfo
 
 # Environment files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "typescript-junie-project",
+  "name": "tg-assistant",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "typescript-junie-project",
+      "name": "tg-assistant",
       "version": "1.0.0",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.990.0",
         "dotenv": "^17.3.1",
@@ -2687,6 +2690,18 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@tg-assistant/common": {
+      "resolved": "packages/common",
+      "link": true
+    },
+    "node_modules/@tg-assistant/feedback": {
+      "resolved": "packages/feedback",
+      "link": true
+    },
+    "node_modules/@tg-assistant/webhook": {
+      "resolved": "packages/webhook",
+      "link": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -5585,9 +5600,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6284,9 +6299,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7592,9 +7607,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7602,6 +7617,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -7712,6 +7730,18 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "packages/common": {
+      "name": "@tg-assistant/common",
+      "version": "0.0.0"
+    },
+    "packages/feedback": {
+      "name": "@tg-assistant/feedback",
+      "version": "0.0.0"
+    },
+    "packages/webhook": {
+      "name": "@tg-assistant/webhook",
+      "version": "0.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "typescript-junie-project",
+  "name": "tg-assistant",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript project configured for Junie Agent in IntelliJ IDEA",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "main": "dist/index.js",
   "scripts": {
     "start": "node dist/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@tg-assistant/common",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@tg-assistant/feedback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@tg-assistant/webhook",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": [
+      "ESNext"
+    ],
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "incremental": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "resolveJsonModule": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,35 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": [
-      "ESNext"
-    ],
     "outDir": "./dist",
-    "rootDir": "./src",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "strictFunctionTypes": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true,
-    "incremental": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "removeComments": false,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "resolveJsonModule": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary
- Rename root package to `tg-assistant`, add `"private": true` and `"workspaces": ["packages/*"]`
- Extract shared compiler options into `tsconfig.base.json` with `"composite": true`, drop unused decorator flags
- Create placeholder `packages/common`, `packages/webhook`, `packages/feedback` with scoped names
- Update `.gitignore` for `packages/*/dist/` and `packages/*/coverage/`
- Fix pre-existing npm audit vulnerabilities (picomatch, yaml)

PR 1 of 4 for #83. No code is moved — all existing build/test/lint pass unchanged.

## Test plan
- [x] `npm run validate` passes (build, lint, format, type-check, test)
- [x] Infrastructure guardrails pass (build, type-check, lint, format, test)
- [x] Pre-commit hook passes all checks including security audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)