### PR TITLE
Fix ESM module resolution for re-export statements

### DIFF
--- a/scripts/fix-imports.js
+++ b/scripts/fix-imports.js
@@ -28,7 +28,7 @@ function fixImports(filePath) {
   // With: import ... from './relative/path.js';
   // Matches relative imports (starting with ./) that don't already have an extension
 
-  const regex = /(import\s+.*?\s+from\s+['"])(\.\.?\/.*?)(['"])/g;
+  const regex = /((?:import|export)\s+.*?\s+from\s+['"])(\.\.?\/.*?)(['"])/g;
 
   let changed = false;
   const newContent = content.replace(regex, (match, p1, p2, p3) => {


### PR DESCRIPTION
## Summary
- Fix `Cannot find module` error in deployed Lambda caused by missing `.js` extensions on re-export specifiers
- Add `export` as an alternative match in the `fix-imports.js` regex so both `import` and `export ... from` statements get `.js` extensions appended

## Test plan
- [x] `npm run build` logs "Fixed imports in common/dist/index.js"
- [x] `packages/common/dist/index.js` re-exports all end with `.js`
- [x] All 31 tests pass with coverage thresholds met
- [x] `lambda-webhook.zip` contains corrected `index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)